### PR TITLE
feat: multiple Whisper model sizes (tiny, small, large-v3, large-v3 t…

### DIFF
--- a/Sources/Views/SetupView.swift
+++ b/Sources/Views/SetupView.swift
@@ -229,8 +229,13 @@ struct ModelSelectionRow: View {
             Spacer()
 
             if isDownloading {
-                ProgressView(value: progress)
-                    .frame(width: 80)
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(isDownloaded || progress >= 1.0 ? "Loading..." : "Downloading...")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    ProgressView(value: progress)
+                        .frame(width: 80)
+                }
             } else if isDownloaded {
                 HStack(spacing: 8) {
                     Text(model.estimatedSize)


### PR DESCRIPTION
# Multiple Whisper model sizes (tiny, small, large-v3, large-v3 turbo)

## Summary

Adds support for multiple Whisper model sizes so users can choose based on accuracy vs speed tradeoff. Previously only base.en was available.

## Changes

- **New models:** tiny.en, small.en, large-v3, large-v3 turbo alongside existing base.en
- **Variant-based loading:** WhisperTranscriber.loadModel(variant:) accepts any WhisperKit variant ID
- **Path persistence:** Model folder paths stored in UserDefaults after download; used for isDownloaded check and deletion
- **Legacy migration:** Existing base.en installs at ~/Documents/huggingface are detected and persisted
- **UI clarity:** "Downloading..." vs "Loading..." label above progress bar so users know what's happening

## Model options

| Model | Size | Languages | Notes |
|-------|------|-----------|-------|
| tiny.en | ~75 MB | English | Smallest, fastest |
| base.en | ~140 MB | English | Default, good balance |
| small.en | ~460 MB | English | Better accuracy |
| large-v3 | ~3 GB | Multilingual | Best accuracy |
| large-v3 turbo | ~954 MB | Multilingual | Optimized large model |

## Technical details

### Files changed (4 files)

**AppState.swift:**
- Added `whisperTinyEn`, `whisperSmallEn`, `whisperLargeV3`, `whisperLargeV3Turbo` cases
- Added `whisperVariant` property returning WhisperKit variant ID for each model
- Modified `storagePath` to read from persisted UserDefaults, with fallback to Application Support
- Added `setStoredWhisperPath(_:for:)` / `getStoredWhisperPath(for:)` for path persistence
- Legacy migration: detects existing base.en at `~/Documents/huggingface` and persists path

**ModelManager.swift:**
- `currentEngine` and `loadModel` handle all 5 Whisper variants
- Passes `model.whisperVariant` to transcriber
- Persists returned model folder URL via `setStoredWhisperPath()`
- `deleteModel` clears persisted path

**WhisperTranscriber.swift:**
- Removed hardcoded `modelVariant = "base.en"`
- New: `loadModel(variant:progressHandler:) async throws -> URL` returns model folder for persistence
- Protocol conformance method calls new one with "base.en" default

**SetupView.swift:**
- Added conditional label above progress bar: "Downloading..." (when fetching files) vs "Loading..." (when initializing after download)

## Notes

- First load of large models on Apple Neural Engine can take several minutes (ANE compilation); subsequent loads are fast (3-5s)
- Only one model loaded at a time; switching unloads current model first
- No changes to build scripts or other infrastructure
