### PR TITLE
feat: add double-tap Control key toggle dictation mode

### DIFF
--- a/Sources/Models/AppState.swift
+++ b/Sources/Models/AppState.swift
@@ -138,6 +138,7 @@ enum HotkeyOption: String, CaseIterable {
     case rightCommand = "rightCommand"
     case hyperKey = "hyperKey"
     case ctrlOptionSpace = "ctrlOptionSpace"
+    case doubleTapControl = "doubleTapControl"
 
     var displayName: String {
         switch self {
@@ -146,7 +147,12 @@ enum HotkeyOption: String, CaseIterable {
         case .rightCommand: return "Right Command (hold)"
         case .hyperKey: return "Hyper Key (hold) – Ctrl+Opt+Cmd+Shift"
         case .ctrlOptionSpace: return "Ctrl+Option+Space (hold)"
+        case .doubleTapControl: return "Double-tap Control (toggle)"
         }
+    }
+
+    var isToggleMode: Bool {
+        self == .doubleTapControl
     }
 
     static var saved: HotkeyOption {

--- a/Sources/Services/AudioFeedbackManager.swift
+++ b/Sources/Services/AudioFeedbackManager.swift
@@ -1,0 +1,42 @@
+import AppKit
+import AVFoundation
+
+/// Provides audio feedback for toggle-mode dictation using macOS dictation sounds.
+class AudioFeedbackManager {
+    static let shared = AudioFeedbackManager()
+
+    private var audioPlayer: AVAudioPlayer?
+
+    // macOS system dictation sounds
+    private let beginRecordPath = "/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/begin_record.caf"
+    private let endRecordPath = "/System/Library/Components/CoreAudio.component/Contents/SharedSupport/SystemSounds/system/end_record.caf"
+
+    private init() {}
+
+    /// Play feedback sound when recording starts (macOS dictation begin sound).
+    func playRecordingStart() {
+        playSound(at: beginRecordPath)
+    }
+
+    /// Play feedback sound when recording stops (macOS dictation end sound).
+    func playRecordingStop() {
+        playSound(at: endRecordPath)
+    }
+
+    private func playSound(at path: String) {
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: path) else {
+            // Fallback to system sounds if dictation sounds not available
+            NSSound(named: "Tink")?.play()
+            return
+        }
+
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: url)
+            audioPlayer?.play()
+        } catch {
+            // Fallback to system sound
+            NSSound(named: "Tink")?.play()
+        }
+    }
+}

--- a/Sources/Services/DictationController.swift
+++ b/Sources/Services/DictationController.swift
@@ -7,13 +7,17 @@ class DictationController {
     private let textInjector = TextInjector()
     private let dictionaryProcessor = DictionaryProcessor()
     private let appState = AppState.shared
+    private let audioFeedback = AudioFeedbackManager.shared
 
     let modelManager = ModelManager()
 
     private var currentRecordingURL: URL?
+    private var currentHotkeyOption: HotkeyOption = HotkeyOption.saved
 
     func updateHotkey(_ option: HotkeyOption) {
+        currentHotkeyOption = option
         hotkeyManager.updateHotkey(option)
+        configureHotkeyCallbacks()
     }
 
     /// Load the selected model (or specified model)
@@ -37,13 +41,41 @@ class DictationController {
             throw DictationError.accessibilityDenied
         }
 
-        hotkeyManager.onKeyDown = { [weak self] in
-            self?.startRecording()
-        }
+        configureHotkeyCallbacks()
+    }
 
-        hotkeyManager.onKeyUp = { [weak self] in
-            self?.stopRecordingAndTranscribe()
+    private func configureHotkeyCallbacks() {
+        if currentHotkeyOption.isToggleMode {
+            // Toggle mode: double-tap to start/stop
+            hotkeyManager.onKeyDown = nil
+            hotkeyManager.onKeyUp = nil
+            hotkeyManager.onToggle = { [weak self] isRecording in
+                if isRecording {
+                    self?.startRecordingWithFeedback()
+                } else {
+                    self?.stopRecordingAndTranscribeWithFeedback()
+                }
+            }
+        } else {
+            // Hold mode: hold to record, release to transcribe
+            hotkeyManager.onToggle = nil
+            hotkeyManager.onKeyDown = { [weak self] in
+                self?.startRecording()
+            }
+            hotkeyManager.onKeyUp = { [weak self] in
+                self?.stopRecordingAndTranscribe()
+            }
         }
+    }
+
+    private func startRecordingWithFeedback() {
+        audioFeedback.playRecordingStart()
+        startRecording()
+    }
+
+    private func stopRecordingAndTranscribeWithFeedback() {
+        audioFeedback.playRecordingStop()
+        stopRecordingAndTranscribe()
     }
 
     private func startRecording() {

--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -11,9 +11,19 @@ class HotkeyManager {
     private let kVK_RightOption: Int64 = 0x3D
     private let kVK_RightCommand: Int64 = 0x36
     private let kVK_Space: Int64 = 0x31
+    private let kVK_LeftControl: Int64 = 0x3B
+    private let kVK_RightControl: Int64 = 0x3E
+
+    // Double-tap detection state
+    private let doubleTapWindow: TimeInterval = 0.4
+    private var lastControlTapTime: TimeInterval?
+    private var isControlCurrentlyHeld: Bool = false
+    private var doubleTapResetTimer: Timer?
+    private var isToggleRecording: Bool = false
 
     var onKeyDown: (() -> Void)?
     var onKeyUp: (() -> Void)?
+    var onToggle: ((Bool) -> Void)?
 
     init(hotkeyOption: HotkeyOption = HotkeyOption.saved) {
         self.hotkeyOption = hotkeyOption
@@ -118,9 +128,26 @@ class HotkeyManager {
                 // Keep active while modifiers held and we're in active state
                 hotkeyPressed = true
             }
+
+        case .doubleTapControl:
+            if type == .flagsChanged {
+                let isControlKey = keyCode == kVK_LeftControl || keyCode == kVK_RightControl
+                let controlPressed = flags.contains(.maskControl)
+
+                if isControlKey && controlPressed && !isControlCurrentlyHeld {
+                    // Control key just pressed
+                    isControlCurrentlyHeld = true
+                } else if isControlKey && !controlPressed && isControlCurrentlyHeld {
+                    // Control key just released - check for double-tap
+                    isControlCurrentlyHeld = false
+                    handleControlRelease()
+                }
+            }
+            // For toggle mode, return early - don't use the standard state transition logic
+            return Unmanaged.passRetained(event)
         }
 
-        // Handle state transitions
+        // Handle state transitions (for hold modes only)
         if hotkeyPressed && !isHotkeyActive {
             isHotkeyActive = true
             DispatchQueue.main.async { [weak self] in
@@ -136,6 +163,30 @@ class HotkeyManager {
         return Unmanaged.passRetained(event)
     }
 
+    private func handleControlRelease() {
+        let now = Date().timeIntervalSince1970
+
+        doubleTapResetTimer?.invalidate()
+        doubleTapResetTimer = nil
+
+        if let lastTap = lastControlTapTime, now - lastTap < doubleTapWindow {
+            // Double-tap detected - toggle recording state
+            isToggleRecording.toggle()
+            lastControlTapTime = nil
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.onToggle?(self.isToggleRecording)
+            }
+        } else {
+            // First tap - record time and start reset timer
+            lastControlTapTime = now
+            doubleTapResetTimer = Timer.scheduledTimer(withTimeInterval: doubleTapWindow, repeats: false) { [weak self] _ in
+                self?.lastControlTapTime = nil
+            }
+        }
+    }
+
     func stop() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
@@ -146,6 +197,13 @@ class HotkeyManager {
         eventTap = nil
         runLoopSource = nil
         isHotkeyActive = false
+
+        // Reset double-tap state
+        doubleTapResetTimer?.invalidate()
+        doubleTapResetTimer = nil
+        lastControlTapTime = nil
+        isControlCurrentlyHeld = false
+        isToggleRecording = false
     }
 
     func updateHotkey(_ option: HotkeyOption) {

--- a/Sources/Views/Settings/GeneralSettingsView.swift
+++ b/Sources/Views/Settings/GeneralSettingsView.swift
@@ -34,7 +34,7 @@ struct GeneralSettingsView: View {
                 // Hotkey Section
                 SettingsSection(title: "Trigger Hotkey") {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Hold this key to start recording, release to transcribe")
+                        Text(hotkeyInstructionText)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .padding(.bottom, 4)
@@ -72,6 +72,14 @@ struct GeneralSettingsView: View {
         .onAppear {
             checkPermissions()
             launchAtLogin = SMAppService.mainApp.status == .enabled
+        }
+    }
+
+    private var hotkeyInstructionText: String {
+        if selectedHotkey.isToggleMode {
+            return "Double-tap this key to start recording, double-tap again to transcribe"
+        } else {
+            return "Hold this key to start recording, release to transcribe"
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a new hotkey option: "Double-tap Control (toggle)" for hands-free dictation
- Double-tap Control to start recording, double-tap again to stop and transcribe
- Audio feedback (start/stop sounds) provides clear indication of recording state
- Ideal for longer dictation sessions where holding a key is uncomfortable

## Changes

- **AppState.swift**: Added `isToggleMode` property to `HotkeyOption`
- **HotkeyManager.swift**: Implemented double-tap detection with 400ms window and `onToggle` callback
- **DictationController.swift**: Added toggle mode handling with audio feedback
- **AudioFeedbackManager.swift**: New manager for start/stop audio cues
- **GeneralSettingsView.swift**: Updated UI to show toggle option

## Test plan

- [ ] Select "Double-tap Control (toggle)" in Settings > General > Activation Hotkey
- [ ] Double-tap Control key - should hear start sound and see recording indicator
- [ ] Speak some text
- [ ] Double-tap Control again - should hear stop sound and text should be transcribed
- [ ] Verify existing hold-to-record hotkeys still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)