### PR TITLE
fix: strip bracketed transcription artifacts from output

### DIFF
--- a/Sources/Services/DictationController.swift
+++ b/Sources/Services/DictationController.swift
@@ -118,6 +118,15 @@ class DictationController {
                     dictionaryHint: dictionaryHint.isEmpty ? nil : dictionaryHint
                 )
 
+                // Strip bracketed transcription artifacts (e.g., [Silence], [BLANK_AUDIO], (Music))
+                text = text.replacingOccurrences(
+                    of: "\\[.*?\\]|\\(.*?\\)",
+                    with: "",
+                    options: .regularExpression
+                )
+                .replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
                 // Post-process with dictionary entries (applies to all engines)
                 let entries = appState.dictionaryState.enabledEntries(for: selectedLanguage)
                 if !entries.isEmpty {


### PR DESCRIPTION
## Summary
- Whisper models sometimes produce artifacts like `[Silence]`, `[BLANK_AUDIO]`, and `(Music)` in transcriptions — especially for short or quiet recordings. These get injected verbatim into the user's text input, which is disruptive.
- Adds a regex post-processing step right after transcription to strip any `[...]` or `(...)` bracketed content, then collapses double-spaces and trims whitespace.

## Test plan
- [ ] Record a short burst of silence or ambient noise — verify no `[BLANK_AUDIO]` or `[Silence]` text is injected
- [ ] Record normal speech — verify transcription output is unchanged
- [ ] Record with music playing — verify `(Music)` tags are stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)