### PR TITLE
Fix downloaded models disappearing from selection UI

### DIFF
--- a/Sources/Models/AppState.swift
+++ b/Sources/Models/AppState.swift
@@ -71,6 +71,29 @@ enum TranscriptionModel: String, CaseIterable {
             if let stored = Self.getStoredWhisperPath(for: self) {
                 return stored
             }
+            // Scan the actual WhisperKit download location for this variant
+            let storageBase: URL
+            if let path = UserDefaults.standard.string(forKey: "modelStorageLocation") {
+                storageBase = URL(fileURLWithPath: path)
+            } else {
+                storageBase = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                    .appendingPathComponent("Speak2")
+                    .appendingPathComponent("Models")
+            }
+            let whisperKitBase = storageBase
+                .appendingPathComponent("models")
+                .appendingPathComponent("argmaxinc")
+                .appendingPathComponent("whisperkit-coreml")
+            if let variant = whisperVariant,
+               FileManager.default.fileExists(atPath: whisperKitBase.path),
+               let folders = try? FileManager.default.contentsOfDirectory(atPath: whisperKitBase.path) {
+                if let match = folders.first(where: { $0.contains(variant) || variant.contains($0) }) {
+                    let foundPath = whisperKitBase.appendingPathComponent(match)
+                    Self.setStoredWhisperPath(foundPath, for: self)
+                    return foundPath
+                }
+            }
+            // Final fallback (legacy path)
             let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
                 .appendingPathComponent("Speak2")
                 .appendingPathComponent("Whisper")
@@ -340,6 +363,8 @@ class AppState: ObservableObject {
             return defaultModelStorageLocation
         }
         set {
+            let currentPath = UserDefaults.standard.string(forKey: "modelStorageLocation")
+            guard currentPath != newValue.path else { return }
             UserDefaults.standard.set(newValue.path, forKey: "modelStorageLocation")
             // Clear all stored model paths since they point to the old location
             for model in TranscriptionModel.allCases {


### PR DESCRIPTION
## Summary

- **Fix `storagePath` fallback**: When the persisted model path is missing from UserDefaults, the fallback now scans the actual WhisperKit download directory (`Models/models/argmaxinc/whisperkit-coreml/`) instead of a nonexistent `Speak2/Whisper/` path. Found paths are re-persisted for fast subsequent lookups.
- **Guard `modelStorageLocation` setter**: Same-value writes no longer wipe all stored model paths, preventing unnecessary fallback to the broken path.

## Context

Models download successfully but then appear as not-downloaded in the UI (showing the download button again). The root cause is a path mismatch — WhisperKit downloads to `Speak2/Models/models/argmaxinc/whisperkit-coreml/<variant>/` but the fallback looked in `Speak2/Whisper/<variant>/`, which is never populated. This fallback is triggered whenever UserDefaults model paths get cleared, which happens when `modelStorageLocation` is written to — even with the same value.

## Test plan

- [ ] Delete `whisperModelPath_*` keys from UserDefaults to simulate cleared state
- [ ] Launch with a model already downloaded on disk — verify it shows as downloaded
- [ ] Download a second model — verify both show as downloaded
- [ ] Test storage location changes don't clear model states when location is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)