### PR TITLE
feat: Add configurable hold-mode key release delay

### DIFF
--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -25,6 +25,20 @@ class HotkeyManager {
 
     private var isSuspended = false
 
+    // Hold-mode key-release delay
+    private var keyUpDelayTimer: Timer?
+
+    static let defaultHoldReleaseDelayMs: Int = 200
+    static let minHoldReleaseDelayMs: Int = 0
+    static let maxHoldReleaseDelayMs: Int = 2000
+
+    private var holdReleaseDelay: TimeInterval {
+        let raw = UserDefaults.standard.object(forKey: "holdReleaseDelayMs") as? Int
+        let ms = raw ?? Self.defaultHoldReleaseDelayMs
+        let clamped = min(max(ms, Self.minHoldReleaseDelayMs), Self.maxHoldReleaseDelayMs)
+        return TimeInterval(clamped) / 1000.0
+    }
+
     var onKeyDown: (() -> Void)?
     var onKeyUp: (() -> Void)?
     var onToggle: ((Bool) -> Void)?
@@ -181,14 +195,29 @@ class HotkeyManager {
 
         // Hold mode: standard state transitions
         if hotkeyPressed && !isHotkeyActive {
+            // Re-pressed during delay — cancel pending key-up and keep recording
+            keyUpDelayTimer?.invalidate()
+            keyUpDelayTimer = nil
+
             isHotkeyActive = true
             DispatchQueue.main.async { [weak self] in
                 self?.onKeyDown?()
             }
         } else if !hotkeyPressed && isHotkeyActive {
-            isHotkeyActive = false
-            DispatchQueue.main.async { [weak self] in
-                self?.onKeyUp?()
+            let delay = holdReleaseDelay
+            if delay > 0 {
+                keyUpDelayTimer?.invalidate()
+                keyUpDelayTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+                    self?.isHotkeyActive = false
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onKeyUp?()
+                    }
+                }
+            } else {
+                isHotkeyActive = false
+                DispatchQueue.main.async { [weak self] in
+                    self?.onKeyUp?()
+                }
             }
         }
 
@@ -254,6 +283,10 @@ class HotkeyManager {
         runLoopSource = nil
         isHotkeyActive = false
         isSuspended = false
+
+        // Reset key-up delay
+        keyUpDelayTimer?.invalidate()
+        keyUpDelayTimer = nil
 
         // Reset double-press state
         doublePressResetTimer?.invalidate()

--- a/Sources/Views/Settings/GeneralSettingsView.swift
+++ b/Sources/Views/Settings/GeneralSettingsView.swift
@@ -11,6 +11,7 @@ struct GeneralSettingsView: View {
     @State private var customCombos: [CustomHotkeyCombo] = HotkeyOption.savedCustomCombos
     @State private var activeComboId: UUID? = HotkeyOption.savedActiveCustomComboId
 
+    @AppStorage("holdReleaseDelayMs") private var holdReleaseDelayMs: Int = HotkeyManager.defaultHoldReleaseDelayMs
     @AppStorage("clipboardRestoreDelayMs") private var clipboardRestoreDelayMs: Int = TextInjector.defaultFallbackDelayMs
     @AppStorage(TranscriptionHistoryState.historyEnabledKey) private var historyEnabled: Bool = true
     @AppStorage(TranscriptionHistoryState.historyRetentionMinutesKey) private var historyRetentionMinutes: Int = 0
@@ -151,6 +152,36 @@ struct GeneralSettingsView: View {
                         Text("When enabled, press the hotkey twice quickly to start recording, and twice again to stop. When disabled, hold the key to record.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
+                        if !isToggleMode {
+                            Divider()
+
+                            HStack {
+                                Text("Release delay")
+                                    .fontWeight(.medium)
+                                Spacer()
+                                TextField(
+                                    "",
+                                    value: $holdReleaseDelayMs,
+                                    format: .number
+                                )
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 70)
+                                .multilineTextAlignment(.trailing)
+                                .onChange(of: holdReleaseDelayMs) { _, newValue in
+                                    let clamped = min(max(newValue, HotkeyManager.minHoldReleaseDelayMs), HotkeyManager.maxHoldReleaseDelayMs)
+                                    if clamped != newValue {
+                                        holdReleaseDelayMs = clamped
+                                    }
+                                }
+                                Text("ms")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text("How long recording continues after you release the hotkey. Increase this if your transcriptions are missing the last word. Range: \(HotkeyManager.minHoldReleaseDelayMs)–\(HotkeyManager.maxHoldReleaseDelayMs)ms.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
 


### PR DESCRIPTION
I found that when using push-to-talk, the end of the transcription is sometimes borked. I had the idea that adding a small delay will improve transcription quality because I release the button a bit to fast. 

This PR adresses this issue and adds a configurable setting that goes from 0 to 2000 ms delay with the default at 200 milliseconds (I personally use 300ms).
This change only affects the push-to-talk feature.

The pull request is only a suggestion but I figured it's easier to just implement the idea.

